### PR TITLE
Fixes #15

### DIFF
--- a/src/json_array_codec.rs
+++ b/src/json_array_codec.rs
@@ -126,7 +126,7 @@ where
                 }
             }
         }
-        self.json_cursor.current_offset += buf.len();
+        self.json_cursor.current_offset = buf.len();
 
         Ok(None)
     }


### PR DESCRIPTION
After every iteration, the JSON cursor offset should point to the end of the buffer, which will correspond to the start of new bytes to read in the next call of the decode method. 

To test this, you need objects that are larger than the number of bits that tokio reads between calls of decode.

