### PR TITLE
docs: Improve feature gating for `docsrs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,4 @@ required-features = ["arrow"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(unused_parens, clippy::new_without_default)]
 #![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Streaming responses support for reqwest for different formats:
 //! - JSON array stream format
@@ -53,33 +54,33 @@
 //! [Apache Arrow IPC]: https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc
 //! [Protobuf]: https://protobuf.dev/programming-guides/encoding/
 
-#[cfg(feature = "json")]
-mod json_stream;
-#[cfg(feature = "json")]
-pub use json_stream::JsonStreamResponse;
-#[cfg(feature = "json")]
-mod json_array_codec;
+#[macro_use]
+mod macros;
 
-#[cfg(feature = "csv")]
-mod csv_stream;
-#[cfg(feature = "csv")]
-pub use csv_stream::CsvStreamResponse;
+cfg_json! {
+    pub use json_stream::JsonStreamResponse;
+    mod json_stream;
+    mod json_array_codec;
+}
+
+cfg_csv! {
+    pub use csv_stream::CsvStreamResponse;
+    mod csv_stream;
+}
 
 use crate::error::StreamBodyError;
 
-#[cfg(feature = "protobuf")]
-mod protobuf_stream;
-#[cfg(feature = "protobuf")]
-pub use protobuf_stream::ProtobufStreamResponse;
-#[cfg(feature = "protobuf")]
-mod protobuf_len_codec;
+cfg_protobuf! {
+    pub use protobuf_stream::ProtobufStreamResponse;
+    mod protobuf_stream;
+    mod protobuf_len_codec;
+}
 
-#[cfg(feature = "arrow")]
-mod arrow_ipc_stream;
-#[cfg(feature = "arrow")]
-pub use arrow_ipc_stream::ArrowIpcStreamResponse;
-#[cfg(feature = "arrow")]
-mod arrow_ipc_len_codec;
+cfg_arrow! {
+    pub use arrow_ipc_stream::ArrowIpcStreamResponse;
+    mod arrow_ipc_stream;
+    mod arrow_ipc_len_codec;
+}
 
 pub mod error;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,39 @@
+macro_rules! cfg_arrow {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "arrow")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "arrow")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_json {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "json")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_csv {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "csv")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "csv")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_protobuf {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "protobuf")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "protobuf")))]
+            $item
+        )*
+    }
+}


### PR DESCRIPTION
This gates different features behind this macro so that, on docs.rs, different features are shown as "Available on crate feature ...".

This is done via:

```rust
  #[cfg_attr(docsrs, doc(cfg(feature = "protobuf")))]
```

This is similar to how crates like `tokio` denote features.


This can be checked locally via:

```bash
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
```