### PR TITLE
feat: Add Send bounds to impl Stream

### DIFF
--- a/src/arrow_ipc_stream.rs
+++ b/src/arrow_ipc_stream.rs
@@ -13,7 +13,7 @@ pub trait ArrowIpcStreamResponse {
     fn arrow_ipc_stream<'a>(
         self,
         max_obj_len: usize,
-    ) -> impl futures::Stream<Item = StreamBodyResult<RecordBatch>> + 'a;
+    ) -> impl futures::Stream<Item = StreamBodyResult<RecordBatch>> + Send + 'a;
 }
 
 #[async_trait]
@@ -45,7 +45,7 @@ impl ArrowIpcStreamResponse for reqwest::Response {
     fn arrow_ipc_stream<'a>(
         self,
         max_obj_len: usize,
-    ) -> impl futures::Stream<Item = StreamBodyResult<RecordBatch>> + 'a {
+    ) -> impl futures::Stream<Item = StreamBodyResult<RecordBatch>>  + Send + 'a {
         let reader = tokio_util::io::StreamReader::new(
             self.bytes_stream()
                 .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),

--- a/src/csv_stream.rs
+++ b/src/csv_stream.rs
@@ -46,7 +46,7 @@ pub trait CsvStreamResponse {
         max_obj_len: usize,
         with_csv_header: bool,
         delimiter: u8,
-    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + 'b
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: for<'de> Deserialize<'de>;
 }
@@ -58,7 +58,7 @@ impl CsvStreamResponse for reqwest::Response {
         max_obj_len: usize,
         with_csv_header: bool,
         delimiter: u8,
-    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + 'b
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: for<'de> Deserialize<'de>,
     {

--- a/src/json_stream.rs
+++ b/src/json_stream.rs
@@ -39,7 +39,7 @@ pub trait JsonStreamResponse {
     ///     Ok(())
     /// }
     /// ```
-    fn json_array_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>> + 'b
+    fn json_array_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: for<'de> Deserialize<'de> + Send + 'b;
 
@@ -79,7 +79,7 @@ pub trait JsonStreamResponse {
         self,
         max_obj_len: usize,
         buf_capacity: usize,
-    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + 'b
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: for<'de> Deserialize<'de> + Send + 'b;
 
@@ -112,7 +112,7 @@ pub trait JsonStreamResponse {
     ///     Ok(())
     /// }
     /// ```
-    fn json_nl_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>> + 'b
+    fn json_nl_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: for<'de> Deserialize<'de> + Send + 'b;
 
@@ -150,7 +150,7 @@ pub trait JsonStreamResponse {
         self,
         max_obj_len: usize,
         buf_capacity: usize,
-    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + 'b
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + Send + 'b
     where
         T: for<'de> Deserialize<'de> + Send + 'b;
 }
@@ -160,7 +160,7 @@ const INITIAL_CAPACITY: usize = 8 * 1024;
 
 #[async_trait]
 impl JsonStreamResponse for reqwest::Response {
-    fn json_nl_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>> + 'b
+    fn json_nl_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: for<'de> Deserialize<'de> + Send + 'b,
     {
@@ -171,7 +171,7 @@ impl JsonStreamResponse for reqwest::Response {
         self,
         max_obj_len: usize,
         buf_capacity: usize,
-    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + 'b
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: for<'de> Deserialize<'de> + Send + 'b
     {
@@ -198,7 +198,7 @@ impl JsonStreamResponse for reqwest::Response {
             })
     }
 
-    fn json_array_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>> + 'b
+    fn json_array_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: for<'de> Deserialize<'de> + Send + 'b,
     {
@@ -209,7 +209,7 @@ impl JsonStreamResponse for reqwest::Response {
         self,
         max_obj_len: usize,
         buf_capacity: usize,
-    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + 'b
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: for<'de> Deserialize<'de> + Send + 'b,
     {

--- a/src/protobuf_stream.rs
+++ b/src/protobuf_stream.rs
@@ -40,14 +40,14 @@ pub trait ProtobufStreamResponse {
     ///     Ok(())
     /// }
     /// ```
-    fn protobuf_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>> + 'b
+    fn protobuf_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: prost::Message + Default + Send + 'b;
 }
 
 #[async_trait]
 impl ProtobufStreamResponse for reqwest::Response {
-    fn protobuf_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>> + 'b
+    fn protobuf_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: prost::Message + Default + Send + 'b,
     {


### PR DESCRIPTION
Moving away from `BoxStream` means we no longer have guaranteed in generic code that the streams are Send, so I've added that bound to all the traits.

