### PR TITLE
feat: Add error and progress hooks and optional tracing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,3 +18,5 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
       - run: cargo fmt -- --check && cargo clippy --all-features -- -Dwarnings && cargo test --all-features
+      # `--all-features` never builds the tracing-off code paths, which would then rot silently.
+      - run: cargo check --features json,csv,protobuf,arrow --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "HTTP body streaming support for reqwest: JSON/CSV/Protobuf and others"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.85"
 homepage = "https://github.com/abdolence/reqwest-streams-rs"
 repository = "https://github.com/abdolence/reqwest-streams-rs"
 documentation = "https://docs.rs/reqwest-streams"
@@ -31,6 +31,8 @@ futures = "0.3"
 csv = { version = "1.3", optional = true }
 prost = { version = "0.14", optional = true }
 arrow = { version = "59", optional = true, features = ["ipc", "arrow-ipc"] }
+# 0.1.30 for `enabled!`
+tracing = { version = "0.1.30", optional = true, default-features = false, features = ["std"] }
 
 [features]
 default = []
@@ -38,17 +40,21 @@ json = ["dep:serde", "dep:serde_json", "reqwest/json"]
 csv = ["dep:csv", "dep:serde"]
 protobuf = ["dep:prost"]
 arrow = ["dep:arrow"]
+tracing = ["dep:tracing"]
 
 [dev-dependencies]
 futures = "0.3"
 hyper = "1"
+http = "1"
 reqwest = { version = "0.13", features = ["json", "stream"] }
 tokio = { version = "1", features = ["full"] }
 prost = { version = "0.14", features = ["derive"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1.0" }
 axum = "0.8"
-axum-streams = { version = "0.26", features = ["json", "csv", "protobuf", "arrow"] }
+axum-streams = { version = "0.28", features = ["json", "csv", "protobuf", "arrow"] }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]
 cargo-husky = { version = "1.5", default-features = false, features = ["run-for-all", "prepush-hook", "run-cargo-fmt"] }
@@ -72,6 +78,11 @@ required-features = ["csv"]
 name = "arrow-stream"
 path = "examples/arrow-stream.rs"
 required-features = ["arrow"]
+
+[[example]]
+name = "tracing-stream"
+path = "examples/tracing-stream.rs"
+required-features = ["json", "tracing"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and want to avoid huge memory allocation.
 Cargo.toml:
 ```toml
 [dependencies]
-reqwest-streams = { version = "0.15", features=["json", "csv", "protobuf", "arrow"] }
+reqwest-streams = { version = "0.17", features=["json", "csv", "protobuf", "arrow"] }
 ```
 
 Example code:
@@ -51,6 +51,111 @@ To run example use:
 ```
 # cargo run --example json-stream
 ```
+
+## Observing errors
+
+An error that happens mid-stream is yielded as an item, so a consumer that stops at the first
+one — `try_collect()`, or `?` inside a loop — silently ends up with a truncated result and no
+indication of why.
+
+Use `on_error` to observe them. It is called for every error, both transport errors and
+decoding errors produced by the format itself:
+
+```rust
+    response.json_array_stream_with_options::<MyTestStructure>(
+        ReqwestStreamOptions::new()
+            .max_obj_len(1024)
+            .on_error(|err| tracing::error!("Stream failed: {err}")),
+    )
+```
+
+Alternatively, enable the `tracing` feature to have the library log them for you:
+
+```toml
+reqwest-streams = { version = "0.17", features = ["json", "tracing"] }
+```
+
+Errors are then logged at the `ERROR` level on the `reqwest_streams` target, so they can be
+filtered with the usual `RUST_LOG=reqwest_streams=off`. Both the log event and your `on_error`
+callback fire when the feature is enabled and a callback is set.
+
+Note that an error is not necessarily the end of the stream. The JSON Lines and CSV formats
+produce their decoding errors from a successfully framed line, so reading resumes with the next
+one; a malformed frame, by contrast, does end the stream.
+
+## Observing progress
+
+A response is read lazily, long after the call that created it returned, so nothing at the call
+site can tell you how much of it actually arrived. Enable the `tracing` feature to have the
+library report that for you:
+
+```toml
+reqwest-streams = { version = "0.17", features = ["json", "tracing"] }
+```
+
+At `INFO` every stream reports its totals once, when it ends:
+
+```text
+INFO reqwest_streams::response_stream{format="json_array" status=200 buf_capacity=8192 max_obj_len=65536 items=300 bytes=8891 errors=0 elapsed_ms=3396 outcome="completed"}: Finished streaming an HTTP body items=300 bytes=8891 errors=0 elapsed_ms=3396 outcome="completed"
+```
+
+The `outcome` tells apart the three ways a stream can end: `completed`, `aborted` (the consumer
+stopped reading early, which is otherwise invisible), and `failed`, which reports at `ERROR`
+instead, alongside the errors themselves. A stream that was built but never polled reports
+nothing at all.
+
+Raise it to `RUST_LOG=reqwest_streams=debug` and long-running streams additionally report
+progress about once a second:
+
+```text
+DEBUG reqwest_streams::response_stream{format="json_array" status=200}: Streaming an HTTP body items=45 bytes=1295 elapsed_ms=510
+DEBUG reqwest_streams::response_stream{format="json_array" status=200}: Streaming an HTTP body items=90 bytes=2600 elapsed_ms=1020
+INFO  reqwest_streams::response_stream{format="json_array" status=200 items=300 bytes=8891 errors=0 elapsed_ms=3396 outcome="completed"}: Finished streaming an HTTP body ...
+```
+
+Everything is recorded on a `reqwest_streams::response_stream` span, created while your own
+span is still current, so collectors nest it under your request and read `items`, `bytes`,
+`errors`, `elapsed_ms` and `outcome` as span attributes rather than as log text. The span also
+carries the response `status` and, when the server sent one, its `content_length` — which is
+what lets you turn `bytes` into a completion percentage. Use `reqwest_streams=trace` to
+additionally get an event per body chunk.
+
+Reporting is time-based by default, so the number of lines is bound by how long a stream runs
+and not by how much it carries. Both triggers are configurable, and progress is also reported
+whenever the item count crosses a step if you ask for one:
+
+```rust
+    response.json_array_stream_with_options::<MyTestStructure>(
+        ReqwestStreamOptions::new()
+            .progress_interval(std::time::Duration::from_secs(5))
+            .progress_items(100_000),
+    )
+```
+
+The same accounting is available without tracing, for metrics:
+
+```rust
+    response.json_array_stream_with_options::<MyTestStructure>(
+        ReqwestStreamOptions::new().on_progress(|progress| {
+            if progress.outcome != ReqwestStreamOutcome::InProgress {
+                metrics::counter!("streamed_bytes").increment(progress.bytes);
+            }
+        }),
+    )
+```
+
+`items` counts the objects successfully decoded, so an item that failed to decode is not
+counted, and an item is whatever the format produces: for the Arrow format that is a
+`RecordBatch`, not a row. `bytes` counts what reqwest handed over, which is *after* transfer-
+and content-decoding — with reqwest's `gzip` or `brotli` features enabled that is the
+decompressed size, not the size on the wire.
+
+Note that `ReqwestStreamOptions::new()` does **not** limit object size: unlike the
+positional-argument methods, which make you choose, `max_obj_len` defaults to `usize::MAX`. Set
+it explicitly when reading from a source you do not control.
+
+Nothing is counted at all unless something is listening: with no `on_error`, no `on_progress`
+and no subscriber interested in `reqwest_streams`, the stream pipeline is left untouched.
 
 ## Need server support?
 There is the same functionality:

--- a/examples/tracing-stream.rs
+++ b/examples/tracing-stream.rs
@@ -1,0 +1,84 @@
+use axum::response::IntoResponse;
+use axum::routing::*;
+use axum::Router;
+use futures::{stream, Stream, StreamExt};
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
+
+use reqwest_streams::{JsonStreamResponse, ReqwestStreamOptions, ReqwestStreamOutcome};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct MyTestStructure {
+    some_test_field: String,
+}
+
+/// A stream slow enough that the progress reports have something to report.
+fn source_test_stream() -> impl Stream<Item = MyTestStructure> {
+    stream::unfold(0usize, |index| async move {
+        if index >= 300 {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let item = MyTestStructure {
+            some_test_field: format!("test{index}"),
+        };
+        Some((item, index + 1))
+    })
+}
+
+async fn test_json_array_stream() -> impl IntoResponse {
+    axum_streams::StreamBodyAs::json_array(source_test_stream())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // `RUST_LOG=reqwest_streams=debug` for a progress line about once a second,
+    // `reqwest_streams=trace` for one per body chunk, `reqwest_streams=off` to silence it.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "reqwest_streams=debug".into()),
+        )
+        .init();
+
+    let app = Router::new().route("/json-array", get(test_json_array_stream));
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
+    let addr = listener.local_addr()?;
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    // The same accounting without tracing: `on_progress` is where you hook up your own
+    // metrics. It fires whether or not the `tracing` feature is enabled.
+    let streamed_bytes = Arc::new(AtomicU64::new(0));
+    let counter = streamed_bytes.clone();
+
+    let stream = reqwest::get(format!("http://{addr}/json-array"))
+        .await?
+        .json_array_stream_with_options::<MyTestStructure>(
+            ReqwestStreamOptions::new()
+                .max_obj_len(64 * 1024)
+                .progress_interval(Duration::from_millis(500))
+                .on_error(|err| tracing::warn!("my own error hook saw: {err}"))
+                .on_progress(move |progress| {
+                    // Only the final snapshot carries a terminal outcome.
+                    if progress.outcome != ReqwestStreamOutcome::InProgress {
+                        counter.fetch_add(progress.bytes, Ordering::Relaxed);
+                    }
+                }),
+        );
+
+    let items: Vec<MyTestStructure> = stream.map(|item| item.unwrap()).collect().await;
+
+    println!("Read {} items", items.len());
+    println!(
+        "on_progress counted {} bytes",
+        streamed_bytes.load(Ordering::Relaxed)
+    );
+
+    Ok(())
+}

--- a/src/arrow_ipc_stream.rs
+++ b/src/arrow_ipc_stream.rs
@@ -1,5 +1,6 @@
 use crate::arrow_ipc_len_codec::ArrowIpcCodec;
-use crate::StreamBodyResult;
+use crate::observability::{self, Progress};
+use crate::{ReqwestStreamOptions, StreamBodyResult};
 use arrow::array::RecordBatch;
 use async_trait::*;
 use futures::TryStreamExt;
@@ -13,6 +14,16 @@ pub trait ArrowIpcStreamResponse {
     fn arrow_ipc_stream<'a>(
         self,
         max_obj_len: usize,
+    ) -> impl futures::Stream<Item = StreamBodyResult<RecordBatch>> + Send + 'a;
+
+    /// Streams the response as batches of Arrow IPC messages, with [`ReqwestStreamOptions`].
+    ///
+    /// This is the variant that gives you the observability hooks: see
+    /// [`ReqwestStreamOptions::on_error`] and [`ReqwestStreamOptions::on_progress`]. Note that
+    /// an item here is a [`RecordBatch`], not a row.
+    fn arrow_ipc_stream_with_options<'a>(
+        self,
+        options: ReqwestStreamOptions,
     ) -> impl futures::Stream<Item = StreamBodyResult<RecordBatch>> + Send + 'a;
 }
 
@@ -46,15 +57,26 @@ impl ArrowIpcStreamResponse for reqwest::Response {
         self,
         max_obj_len: usize,
     ) -> impl futures::Stream<Item = StreamBodyResult<RecordBatch>>  + Send + 'a {
-        let reader = tokio_util::io::StreamReader::new(
+        self.arrow_ipc_stream_with_options(ReqwestStreamOptions::new().max_obj_len(max_obj_len))
+    }
+
+    fn arrow_ipc_stream_with_options<'a>(
+        self,
+        options: ReqwestStreamOptions,
+    ) -> impl futures::Stream<Item = StreamBodyResult<RecordBatch>> + Send + 'a {
+        // Taken before `bytes_stream()` consumes the response.
+        let progress = Progress::new("arrow", &self, &options);
+
+        let reader = tokio_util::io::StreamReader::new(observability::count_bytes(
             self.bytes_stream()
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
-        );
+                .map_err(std::io::Error::other),
+            &progress,
+        ));
 
-        let codec = ArrowIpcCodec::new_with_max_length(max_obj_len);
-        let frames_reader = tokio_util::codec::FramedRead::new(reader, codec);
+        let codec = ArrowIpcCodec::new_with_max_length(options.max_obj_len);
+        let frames_reader = tokio_util::codec::FramedRead::with_capacity(reader, codec, options.buf_capacity);
 
-        frames_reader.into_stream()
+        observability::instrument(frames_reader.into_stream(), progress)
     }
 }
 

--- a/src/csv_stream.rs
+++ b/src/csv_stream.rs
@@ -1,5 +1,6 @@
 use crate::error::StreamBodyKind;
-use crate::{StreamBodyError, StreamBodyResult};
+use crate::observability::{self, Progress};
+use crate::{ReqwestStreamOptions, StreamBodyError, StreamBodyResult};
 use async_trait::*;
 use futures::{StreamExt, TryStreamExt};
 use serde::Deserialize;
@@ -49,6 +50,22 @@ pub trait CsvStreamResponse {
     ) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: for<'de> Deserialize<'de>;
+
+    /// Streams the response as CSV, with [`ReqwestStreamOptions`].
+    ///
+    /// `with_csv_header` and `delimiter` stay here rather than moving into the options because
+    /// they describe the CSV format itself, not how the stream is read.
+    ///
+    /// This is the variant that gives you the observability hooks: see
+    /// [`ReqwestStreamOptions::on_error`] and [`ReqwestStreamOptions::on_progress`].
+    fn csv_stream_with_options<'a, 'b, T>(
+        self,
+        with_csv_header: bool,
+        delimiter: u8,
+        options: ReqwestStreamOptions,
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + Send + 'b
+    where
+        T: for<'de> Deserialize<'de>;
 }
 
 #[async_trait]
@@ -62,20 +79,47 @@ impl CsvStreamResponse for reqwest::Response {
     where
         T: for<'de> Deserialize<'de>,
     {
-        let reader = StreamReader::new(
+        self.csv_stream_with_options(
+            with_csv_header,
+            delimiter,
+            ReqwestStreamOptions::new().max_obj_len(max_obj_len),
+        )
+    }
+
+    fn csv_stream_with_options<'a, 'b, T>(
+        self,
+        with_csv_header: bool,
+        delimiter: u8,
+        options: ReqwestStreamOptions,
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + Send + 'b
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        // Taken before `bytes_stream()` consumes the response.
+        let progress = Progress::new("csv", &self, &options);
+
+        let reader = StreamReader::new(observability::count_bytes(
             self.bytes_stream()
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
-        );
+                .map_err(std::io::Error::other),
+            &progress,
+        ));
 
-        let codec = tokio_util::codec::LinesCodec::new_with_max_length(max_obj_len);
-        let frames_reader = tokio_util::codec::FramedRead::new(reader, codec);
+        let codec = tokio_util::codec::LinesCodec::new_with_max_length(options.max_obj_len);
+        let frames_reader = tokio_util::codec::FramedRead::with_capacity(reader, codec, options.buf_capacity);
 
-        #[allow(clippy::bool_to_int_with_if)] // false positive: it is not bool to int
-        let skip_header_if_expected = if with_csv_header { 1 } else { 0 };
+        // Not `.skip(1)`: that would drop the first frame whether it decoded or not, so a
+        // header line that failed to frame — one longer than `max_obj_len`, say — would be
+        // swallowed, and the stream would report itself as having completed cleanly. Consume
+        // the header slot either way, but yield its error when there is one.
+        let mut header_pending = with_csv_header;
 
-        frames_reader
+        let rows = frames_reader
             .into_stream()
-            .skip(skip_header_if_expected)
+            .filter_map(move |frame_res| {
+                let is_header = header_pending && frame_res.is_ok();
+                header_pending = false;
+                futures::future::ready(if is_header { None } else { Some(frame_res) })
+            })
             .map(move |frame_res| match frame_res {
                 Ok(frame_str) => {
                     let mut csv_reader = csv::ReaderBuilder::new()
@@ -103,7 +147,10 @@ impl CsvStreamResponse for reqwest::Response {
                     Some(Box::new(err)),
                     None,
                 )),
-            })
+            });
+
+        // Wrapped after the `skip`, so the header row is not counted as an item.
+        observability::instrument(rows, progress)
     }
 }
 
@@ -147,7 +194,8 @@ mod tests {
             .send()
             .await
             .unwrap()
-            .csv_stream::<MyTestStructure>(1024, false, b',');
+            // `StreamBodyAs::csv` writes a header row, so the client has to skip one.
+            .csv_stream::<MyTestStructure>(1024, true, b',');
         let items: Vec<MyTestStructure> = res.try_collect().await.unwrap();
 
         assert_eq!(items, test_stream_vec);

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,20 @@ pub enum StreamBodyKind {
     MaxLenReachedError,
 }
 
+impl StreamBodyKind {
+    /// A short, stable name for this kind, reported as the `error_kind` tracing field so that
+    /// errors can be aggregated without parsing their [`Display`] output.
+    ///
+    /// [`Display`]: fmt::Display
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            StreamBodyKind::CodecError => "codec",
+            StreamBodyKind::InputOutputError => "io",
+            StreamBodyKind::MaxLenReachedError => "max_len",
+        }
+    }
+}
+
 impl fmt::Debug for StreamBodyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut builder = f.debug_struct("reqwest::Error");

--- a/src/json_stream.rs
+++ b/src/json_stream.rs
@@ -1,6 +1,7 @@
 use crate::error::StreamBodyKind;
 use crate::json_array_codec::JsonArrayCodec;
-use crate::{StreamBodyError, StreamBodyResult};
+use crate::observability::{self, Progress, INITIAL_CAPACITY};
+use crate::{ReqwestStreamOptions, StreamBodyError, StreamBodyResult};
 use async_trait::*;
 use futures::{StreamExt, TryStreamExt};
 use serde::Deserialize;
@@ -153,10 +154,54 @@ pub trait JsonStreamResponse {
     ) -> impl futures::Stream<Item = StreamBodyResult<T>> + Send + 'b
     where
         T: for<'de> Deserialize<'de> + Send + 'b;
-}
 
-// This is the default capacity of the buffer used by StreamReader
-const INITIAL_CAPACITY: usize = 8 * 1024;
+    /// Streams the response as a JSON array, with [`ReqwestStreamOptions`].
+    ///
+    /// This is the variant that gives you the observability hooks: see
+    /// [`ReqwestStreamOptions::on_error`] and [`ReqwestStreamOptions::on_progress`].
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use reqwest_streams::{JsonStreamResponse as _, ReqwestStreamOptions};
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Debug, Clone, Deserialize)]
+    /// struct MyTestStructure {
+    ///     some_test_field: String
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let _stream = reqwest::get("http://localhost:8080/json-array")
+    ///         .await?
+    ///         .json_array_stream_with_options::<MyTestStructure>(
+    ///             ReqwestStreamOptions::new()
+    ///                 .max_obj_len(64 * 1024)
+    ///                 .on_error(|err| eprintln!("stream error: {err}")),
+    ///         );
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    fn json_array_stream_with_options<'a, 'b, T>(
+        self,
+        options: ReqwestStreamOptions,
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + Send + 'b
+    where
+        T: for<'de> Deserialize<'de> + Send + 'b;
+
+    /// Streams the response as JSON lines (NL/NewLines), with [`ReqwestStreamOptions`].
+    ///
+    /// This is the variant that gives you the observability hooks: see
+    /// [`ReqwestStreamOptions::on_error`] and [`ReqwestStreamOptions::on_progress`].
+    fn json_nl_stream_with_options<'a, 'b, T>(
+        self,
+        options: ReqwestStreamOptions,
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + Send + 'b
+    where
+        T: for<'de> Deserialize<'de> + Send + 'b;
+}
 
 #[async_trait]
 impl JsonStreamResponse for reqwest::Response {
@@ -175,27 +220,48 @@ impl JsonStreamResponse for reqwest::Response {
     where
         T: for<'de> Deserialize<'de> + Send + 'b
     {
-        let reader = StreamReader::new(
+        self.json_nl_stream_with_options(
+            ReqwestStreamOptions::new()
+                .max_obj_len(max_obj_len)
+                .buf_capacity(buf_capacity),
+        )
+    }
+
+    fn json_nl_stream_with_options<'a, 'b, T>(
+        self,
+        options: ReqwestStreamOptions,
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + Send + 'b
+    where
+        T: for<'de> Deserialize<'de> + Send + 'b,
+    {
+        // Taken before `bytes_stream()` consumes the response.
+        let progress = Progress::new("json_nl", &self, &options);
+
+        let reader = StreamReader::new(observability::count_bytes(
             self.bytes_stream()
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
-        );
+                .map_err(std::io::Error::other),
+            &progress,
+        ));
 
-        let codec = tokio_util::codec::LinesCodec::new_with_max_length(max_obj_len);
+        let codec = tokio_util::codec::LinesCodec::new_with_max_length(options.max_obj_len);
         let frames_reader =
-            tokio_util::codec::FramedRead::with_capacity(reader, codec, buf_capacity);
+            tokio_util::codec::FramedRead::with_capacity(reader, codec, options.buf_capacity);
 
-        frames_reader
-            .into_stream()
-            .map(|frame_res| match frame_res {
-                Ok(frame_str) => serde_json::from_str(frame_str.as_str()).map_err(|err| {
-                    StreamBodyError::new(StreamBodyKind::CodecError, Some(Box::new(err)), None)
+        observability::instrument(
+            frames_reader
+                .into_stream()
+                .map(|frame_res| match frame_res {
+                    Ok(frame_str) => serde_json::from_str(frame_str.as_str()).map_err(|err| {
+                        StreamBodyError::new(StreamBodyKind::CodecError, Some(Box::new(err)), None)
+                    }),
+                    Err(err) => Err(StreamBodyError::new(
+                        StreamBodyKind::CodecError,
+                        Some(Box::new(err)),
+                        None,
+                    )),
                 }),
-                Err(err) => Err(StreamBodyError::new(
-                    StreamBodyKind::CodecError,
-                    Some(Box::new(err)),
-                    None,
-                )),
-            })
+            progress,
+        )
     }
 
     fn json_array_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
@@ -213,17 +279,34 @@ impl JsonStreamResponse for reqwest::Response {
     where
         T: for<'de> Deserialize<'de> + Send + 'b,
     {
-        let reader = StreamReader::new(
+        self.json_array_stream_with_options(
+            ReqwestStreamOptions::new()
+                .max_obj_len(max_obj_len)
+                .buf_capacity(buf_capacity),
+        )
+    }
+
+    fn json_array_stream_with_options<'a, 'b, T>(
+        self,
+        options: ReqwestStreamOptions,
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + Send + 'b
+    where
+        T: for<'de> Deserialize<'de> + Send + 'b,
+    {
+        // Taken before `bytes_stream()` consumes the response.
+        let progress = Progress::new("json_array", &self, &options);
+
+        let reader = StreamReader::new(observability::count_bytes(
             self.bytes_stream()
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
-        );
+                .map_err(std::io::Error::other),
+            &progress,
+        ));
 
-        //serde_json::from_reader(read);
-        let codec = JsonArrayCodec::<T>::new_with_max_length(max_obj_len);
+        let codec = JsonArrayCodec::<T>::new_with_max_length(options.max_obj_len);
         let frames_reader =
-            tokio_util::codec::FramedRead::with_capacity(reader, codec, buf_capacity);
+            tokio_util::codec::FramedRead::with_capacity(reader, codec, options.buf_capacity);
 
-        frames_reader.into_stream()
+        observability::instrument(frames_reader.into_stream(), progress)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 //! - `csv`: CSV stream format
 //! - `protobuf`: [Protobuf] len-prefixed stream format
 //! - `arrow`: [Apache Arrow IPC] stream format
+//! - `tracing`: report progress and errors through [tracing]
 //!
 //! # Example
 //!
@@ -51,6 +52,32 @@
 //! - [axum-streams](https://github.com/abdolence/axum-streams-rs).
 //!
 //!
+//! # Observing stream errors
+//!
+//! An error that happens mid-stream is yielded as an item, so a consumer that stops at the
+//! first one silently gets a truncated result. Use [`ReqwestStreamOptions::on_error`] to
+//! observe them, or enable the `tracing` feature to have them logged at `ERROR` on the
+//! `reqwest_streams` target.
+//!
+//! # Observing stream progress
+//!
+//! Nothing at the call site can tell you how much of a response actually arrived, because it
+//! is read long after the call returned. With the `tracing` feature every stream reports its
+//! totals once at `INFO` when it ends, on a `reqwest_streams::response_stream` span:
+//!
+//! ```text
+//! INFO reqwest_streams::response_stream{format="json_array" status=200 items=1000 bytes=28001 elapsed_ms=11239 outcome="completed"}: Finished streaming an HTTP body
+//! ```
+//!
+//! The `outcome` tells apart the three ways a stream can end: `completed`, `aborted` (the
+//! consumer stopped reading early) and `failed`, which reports at `ERROR` instead. Raise the
+//! filter to `reqwest_streams=debug` for a progress line about once a second, and to
+//! `reqwest_streams=trace` for one per body chunk.
+//!
+//! The same accounting is available without tracing, for metrics, via
+//! [`ReqwestStreamOptions::on_progress`].
+//!
+//! [tracing]: https://docs.rs/tracing
 //! [Apache Arrow IPC]: https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc
 //! [Protobuf]: https://protobuf.dev/programming-guides/encoding/
 
@@ -69,6 +96,12 @@ cfg_csv! {
 }
 
 use crate::error::StreamBodyError;
+
+mod observability;
+pub use observability::{
+    ReqwestStreamErrorHandler, ReqwestStreamOptions, ReqwestStreamOutcome, ReqwestStreamProgress,
+    ReqwestStreamProgressHandler,
+};
 
 cfg_protobuf! {
     pub use protobuf_stream::ProtobufStreamResponse;

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1,0 +1,620 @@
+//! Observing how much of a streamed response actually arrived.
+//!
+//! A streaming response is consumed lazily, long after the call that created it returned, so
+//! nothing at the call site can say how much of it arrived, whether it was truncated by a
+//! decode error, or that the consumer walked away after ten items. This module accounts for
+//! all of that and reports it two ways: through the [`on_progress`] / [`on_error`] callbacks,
+//! which are always available, and through `tracing` when the `tracing` feature is enabled.
+//!
+//! [`on_progress`]: ReqwestStreamOptions::on_progress
+//! [`on_error`]: ReqwestStreamOptions::on_error
+
+use crate::error::StreamBodyError;
+use crate::StreamBodyResult;
+use bytes::Bytes;
+use futures::{Stream, TryStreamExt};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+/// This is the default capacity of the buffer used by `StreamReader`.
+pub(crate) const INITIAL_CAPACITY: usize = 8 * 1024;
+
+/// How often progress is reported when it is not otherwise configured.
+///
+/// Time-based rather than item-based on purpose: the volume of progress reports is then bound
+/// by how long the stream runs and not by how much it carries, so even a multi-million item
+/// stream cannot flood the logs.
+const DEFAULT_PROGRESS_INTERVAL: Duration = Duration::from_secs(1);
+
+/// How a streamed response ended, or that it is still going.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReqwestStreamOutcome {
+    /// A periodic snapshot: the response is still being read.
+    InProgress,
+    /// The response body ended and every item was handed over.
+    Completed,
+    /// The stream ended after at least one error, so items are missing.
+    Failed,
+    /// The stream was dropped before the body ended, typically because the consumer stopped
+    /// reading early.
+    Aborted,
+}
+
+impl ReqwestStreamOutcome {
+    /// The value used for the `outcome` tracing field.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ReqwestStreamOutcome::InProgress => "in_progress",
+            ReqwestStreamOutcome::Completed => "completed",
+            ReqwestStreamOutcome::Failed => "failed",
+            ReqwestStreamOutcome::Aborted => "aborted",
+        }
+    }
+}
+
+/// A snapshot of how much of a streamed response has been read so far.
+///
+/// `items` counts the objects successfully decoded, so an item that failed to decode is not
+/// counted. Note that an item is whatever the format produces: for the Arrow format that is a
+/// `RecordBatch`, not a row.
+///
+/// `bytes` counts the body bytes reqwest handed over, which is *after* transfer- and
+/// content-decoding. If you enabled reqwest's `gzip` or `brotli` features this is therefore
+/// the decompressed size, not the size on the wire.
+#[derive(Debug, Clone, Copy)]
+pub struct ReqwestStreamProgress {
+    pub items: u64,
+    pub bytes: u64,
+    pub errors: u64,
+    pub elapsed: Duration,
+    pub outcome: ReqwestStreamOutcome,
+}
+
+/// A callback invoked for every error produced while reading a streamed response.
+pub type ReqwestStreamErrorHandler = Arc<dyn Fn(&StreamBodyError) + Send + Sync + 'static>;
+
+/// A callback invoked with progress snapshots while reading a streamed response.
+pub type ReqwestStreamProgressHandler = Arc<dyn Fn(&ReqwestStreamProgress) + Send + Sync + 'static>;
+
+/// Options shared by every streaming format.
+///
+/// Build these with [`ReqwestStreamOptions::new`] and the setters below rather than with a
+/// struct literal, so that later options can be added without breaking you.
+///
+/// # Note on `max_obj_len`
+///
+/// Unlike the positional-argument methods, which make you choose a limit, a freshly built
+/// `ReqwestStreamOptions` does **not** limit object size — [`max_obj_len`] defaults to
+/// [`usize::MAX`]. Set it explicitly when reading from a source you do not control.
+///
+/// [`max_obj_len`]: ReqwestStreamOptions::max_obj_len
+#[non_exhaustive]
+pub struct ReqwestStreamOptions {
+    pub max_obj_len: usize,
+    pub buf_capacity: usize,
+    pub on_error: Option<ReqwestStreamErrorHandler>,
+    pub on_progress: Option<ReqwestStreamProgressHandler>,
+    pub progress_interval: Option<Duration>,
+    pub progress_items: Option<u64>,
+}
+
+impl Default for ReqwestStreamOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReqwestStreamOptions {
+    pub fn new() -> Self {
+        Self {
+            max_obj_len: usize::MAX,
+            buf_capacity: INITIAL_CAPACITY,
+            on_error: None,
+            on_progress: None,
+            progress_interval: Some(DEFAULT_PROGRESS_INTERVAL),
+            progress_items: None,
+        }
+    }
+
+    /// The maximum size in bytes of a single decoded object.
+    ///
+    /// [`usize::MAX`], the default, means no limit.
+    pub fn max_obj_len(mut self, max_obj_len: usize) -> Self {
+        self.max_obj_len = max_obj_len;
+        self
+    }
+
+    /// The initial capacity of the stream's decoding buffer.
+    pub fn buf_capacity(mut self, buf_capacity: usize) -> Self {
+        self.buf_capacity = buf_capacity;
+        self
+    }
+
+    /// Registers a callback invoked for every error produced while reading the response,
+    /// covering both transport errors and decoding errors produced by the format itself.
+    ///
+    /// The error is still yielded by the stream; this is purely an observation hook. It does
+    /// not replace the `tracing` feature: when that feature is enabled both the log event and
+    /// this callback fire.
+    pub fn on_error<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&StreamBodyError) + Send + Sync + 'static,
+    {
+        self.on_error = Some(Arc::new(handler));
+        self
+    }
+
+    /// Registers a callback receiving progress snapshots while the response is read: one per
+    /// reporting interval or item step, plus a final one carrying the totals and how the
+    /// stream ended (completed, failed, or aborted because the consumer stopped reading).
+    ///
+    /// This is the same accounting the `tracing` feature reports, exposed for metrics: wire it
+    /// to a counter and you get streamed items and bytes without depending on tracing at all.
+    /// When the feature is enabled both happen.
+    ///
+    /// The counters are only maintained when someone is listening, so a stream with no
+    /// callback and no `tracing` subscriber interested in `reqwest_streams` pays nothing.
+    pub fn on_progress<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&ReqwestStreamProgress) + Send + Sync + 'static,
+    {
+        self.on_progress = Some(Arc::new(handler));
+        self
+    }
+
+    /// Reports progress at most once per `interval` (one second by default).
+    ///
+    /// Set the field to `None` directly to report on item steps only.
+    pub fn progress_interval(mut self, interval: Duration) -> Self {
+        self.progress_interval = Some(interval);
+        self
+    }
+
+    /// Additionally reports progress every `items` items.
+    ///
+    /// Off by default, and deliberately so: it is a linear step, so a large stream reports a
+    /// number of times proportional to its size. Prefer [`Self::progress_interval`] unless you
+    /// specifically want item-granular checkpoints.
+    pub fn progress_items(mut self, items: u64) -> Self {
+        self.progress_items = Some(items);
+        self
+    }
+}
+
+/// Lets [`ProgressStream`] classify items without being generic over the item type.
+///
+/// A `T` that appeared only in a `where` clause would be an unconstrained type parameter
+/// (E0207), and a `PhantomData<T>` would drag `T`'s auto traits into the stream's type — which
+/// would break `csv_stream`, whose `T` carries no `Send + 'b` bound even though the method
+/// promises them.
+pub(crate) trait ProgressItem {
+    fn stream_error(&self) -> Option<&StreamBodyError>;
+}
+
+impl<T> ProgressItem for StreamBodyResult<T> {
+    fn stream_error(&self) -> Option<&StreamBodyError> {
+        self.as_ref().err()
+    }
+}
+
+/// Shared accounting for one streamed response.
+///
+/// Bytes are counted on the body stream and items on the decoded stream, so the two counters
+/// live in different combinators and share this state. The ordering is `Relaxed` throughout:
+/// these are counters, not synchronisation.
+struct ProgressState {
+    items: AtomicU64,
+    bytes: AtomicU64,
+    errors: AtomicU64,
+    last_emit_micros: AtomicU64,
+    next_item_step: AtomicU64,
+    polled: AtomicBool,
+    finalized: AtomicBool,
+    start: Instant,
+    interval_micros: Option<u64>,
+    item_step: Option<u64>,
+    on_error: Option<ReqwestStreamErrorHandler>,
+    on_progress: Option<ReqwestStreamProgressHandler>,
+    #[cfg(feature = "tracing")]
+    span: tracing::Span,
+}
+
+/// Checked at `ERROR`, the least verbose level the accounting can produce: a failed stream
+/// reports there, so gating any higher would mean `RUST_LOG=reqwest_streams=error` silently
+/// loses the totals of the very streams it asked about. Every more verbose filter enables
+/// `ERROR` too, so this can never suppress wanted output.
+#[cfg(feature = "tracing")]
+fn tracing_enabled() -> bool {
+    tracing::enabled!(target: "reqwest_streams", tracing::Level::ERROR)
+}
+
+#[cfg(not(feature = "tracing"))]
+fn tracing_enabled() -> bool {
+    false
+}
+
+impl ProgressState {
+    /// Returns `None` when nobody is listening, in which case every accounting call below
+    /// short-circuits on a single `Option` check.
+    #[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
+    fn maybe_new(
+        format: &'static str,
+        response: &reqwest::Response,
+        options: &ReqwestStreamOptions,
+    ) -> Option<Arc<Self>> {
+        if options.on_progress.is_none() && options.on_error.is_none() && !tracing_enabled() {
+            return None;
+        }
+
+        // A step of zero would never advance, so treat it as "disabled" rather than looping.
+        let item_step = options.progress_items.filter(|step| *step > 0);
+
+        Some(Arc::new(Self {
+            items: AtomicU64::new(0),
+            bytes: AtomicU64::new(0),
+            errors: AtomicU64::new(0),
+            last_emit_micros: AtomicU64::new(0),
+            next_item_step: AtomicU64::new(item_step.unwrap_or(u64::MAX)),
+            polled: AtomicBool::new(false),
+            finalized: AtomicBool::new(false),
+            start: Instant::now(),
+            interval_micros: options
+                .progress_interval
+                .map(|interval| interval.as_micros() as u64),
+            item_step,
+            on_error: options.on_error.clone(),
+            on_progress: options.on_progress.clone(),
+            #[cfg(feature = "tracing")]
+            span: Self::new_span(format, response, options),
+        }))
+    }
+
+    /// The span covering the whole stream, created here, while the caller's own span is still
+    /// the current one, so collectors nest it under their request rather than orphaning it.
+    /// The stream itself is polled later, potentially from an entirely different task.
+    ///
+    /// Every counter is declared up front as an empty field so it can be filled in later with
+    /// [`tracing::Span::record`]: collectors that read span attributes (OpenTelemetry and
+    /// friends) then see `items`/`bytes`/`outcome` as structured values on a span whose
+    /// duration is the streaming duration, instead of having to parse log messages.
+    ///
+    /// The response is still owned at this point, which is a client-side opportunity the
+    /// server side does not have: `status` and `content_length` go on the span, and the
+    /// latter is what lets an operator turn `bytes` into a completion percentage. The URL is
+    /// deliberately *not* recorded — it carries query strings and userinfo, which routinely
+    /// means presigned-URL signatures and `?api_key=`.
+    #[cfg(feature = "tracing")]
+    fn new_span(
+        format: &'static str,
+        response: &reqwest::Response,
+        options: &ReqwestStreamOptions,
+    ) -> tracing::Span {
+        let span = tracing::info_span!(
+            target: "reqwest_streams",
+            "reqwest_streams::response_stream",
+            format = format,
+            status = response.status().as_u16(),
+            // `Option` is a `Value` that simply skips the field when it is empty.
+            content_length = response.content_length(),
+            max_obj_len = tracing::field::Empty,
+            buf_capacity = options.buf_capacity as u64,
+            items = tracing::field::Empty,
+            bytes = tracing::field::Empty,
+            errors = tracing::field::Empty,
+            elapsed_ms = tracing::field::Empty,
+            outcome = tracing::field::Empty,
+        );
+
+        // `usize::MAX` means "no limit", which is noise rather than information.
+        if options.max_obj_len != usize::MAX {
+            span.record("max_obj_len", options.max_obj_len as u64);
+        }
+
+        span
+    }
+
+    fn record_bytes(&self, len: u64) {
+        let bytes = self.bytes.fetch_add(len, Ordering::Relaxed) + len;
+        let items = self.items.load(Ordering::Relaxed);
+
+        #[cfg(feature = "tracing")]
+        tracing::trace!(
+            target: "reqwest_streams",
+            parent: &self.span,
+            chunk_bytes = len,
+            items,
+            bytes,
+            "Read an HTTP body chunk"
+        );
+
+        // Progress is driven from arriving bytes as well as from decoded items, because a
+        // single item can take a long time to arrive: one large Arrow batch, or a JSON array
+        // streamed slowly, would otherwise report nothing at all until it completed. Emitting
+        // resets the interval, so a chunk and an item cannot both report for the same tick.
+        if !self.finalized.load(Ordering::Relaxed) && self.should_emit(items) {
+            self.emit(
+                ReqwestStreamOutcome::InProgress,
+                items,
+                bytes,
+                self.errors.load(Ordering::Relaxed),
+            );
+        }
+    }
+
+    fn record_item(&self) {
+        let items = self.items.fetch_add(1, Ordering::Relaxed) + 1;
+
+        // Nothing may be reported after the summary, or the final snapshot would no longer be
+        // final. A consumer is free to keep polling a stream past its end.
+        if !self.finalized.load(Ordering::Relaxed) && self.should_emit(items) {
+            self.emit(
+                ReqwestStreamOutcome::InProgress,
+                items,
+                self.bytes.load(Ordering::Relaxed),
+                self.errors.load(Ordering::Relaxed),
+            );
+        }
+    }
+
+    /// Errors are reported as they happen but are deliberately **not** terminal.
+    ///
+    /// Only some of them are: `FramedRead` latches its own error state and ends the stream,
+    /// but the JSON Lines and CSV formats produce their decoding errors from a successfully
+    /// framed line, and the stream carries on to the next one. Finalising here would stop
+    /// counting the remaining items of a stream that is still perfectly healthy, so the
+    /// terminal outcome is decided at the end instead, from this counter.
+    fn record_error(&self, err: &StreamBodyError) {
+        self.errors.fetch_add(1, Ordering::Relaxed);
+
+        #[cfg(feature = "tracing")]
+        tracing::error!(
+            target: "reqwest_streams",
+            parent: &self.span,
+            error = %err,
+            error_kind = err.kind().as_str(),
+            "An error occurred while streaming an HTTP body"
+        );
+
+        if let Some(handler) = &self.on_error {
+            handler(err);
+        }
+    }
+
+    /// The two triggers are OR'd, and emitting resets both, so an item produces at most one
+    /// progress event.
+    fn should_emit(&self, items: u64) -> bool {
+        let mut emit = false;
+
+        if let Some(step) = self.item_step {
+            if items >= self.next_item_step.load(Ordering::Relaxed) {
+                // Skip past every step the current count already crossed, so a single poll
+                // carrying many items cannot queue up a burst of events.
+                self.next_item_step
+                    .store(items - (items % step) + step, Ordering::Relaxed);
+                emit = true;
+            }
+        }
+
+        if let Some(interval) = self.interval_micros {
+            let elapsed = self.start.elapsed().as_micros() as u64;
+            let since_last = elapsed.saturating_sub(self.last_emit_micros.load(Ordering::Relaxed));
+            if emit || since_last >= interval {
+                self.last_emit_micros.store(elapsed, Ordering::Relaxed);
+                emit = true;
+            }
+        }
+
+        emit
+    }
+
+    fn mark_polled(&self) {
+        self.polled.store(true, Ordering::Relaxed);
+    }
+
+    /// Emits the terminal snapshot, exactly once per stream.
+    ///
+    /// A stream that was never polled reports nothing at all. Building one and dropping it
+    /// unconsumed is routine on the client — a `?` short-circuits, a function returns early —
+    /// and reporting those as aborted would bury the real ones in `items=0 bytes=0` noise.
+    fn finalize(&self, aborted: bool) {
+        if !self.polled.load(Ordering::Relaxed) || self.finalized.swap(true, Ordering::Relaxed) {
+            return;
+        }
+
+        let items = self.items.load(Ordering::Relaxed);
+        let bytes = self.bytes.load(Ordering::Relaxed);
+        let errors = self.errors.load(Ordering::Relaxed);
+
+        let outcome = if errors > 0 {
+            ReqwestStreamOutcome::Failed
+        } else if aborted {
+            ReqwestStreamOutcome::Aborted
+        } else {
+            ReqwestStreamOutcome::Completed
+        };
+
+        // Recorded once, here rather than on every progress report: subscribers are free to
+        // treat `record` as append-only (`tracing-subscriber`'s formatter does), so writing a
+        // field repeatedly makes the rendered span grow with every tick. Once per span also
+        // means the values a collector reads are the final ones.
+        #[cfg(feature = "tracing")]
+        {
+            self.span.record("items", items);
+            self.span.record("bytes", bytes);
+            self.span.record("errors", errors);
+            self.span
+                .record("elapsed_ms", self.start.elapsed().as_millis() as u64);
+            self.span.record("outcome", outcome.as_str());
+        }
+
+        self.emit(outcome, items, bytes, errors);
+    }
+
+    fn emit(&self, outcome: ReqwestStreamOutcome, items: u64, bytes: u64, errors: u64) {
+        let progress = ReqwestStreamProgress {
+            items,
+            bytes,
+            errors,
+            elapsed: self.start.elapsed(),
+            outcome,
+        };
+
+        #[cfg(feature = "tracing")]
+        {
+            let elapsed_ms = progress.elapsed.as_millis() as u64;
+
+            match outcome {
+                // Interim progress is chatter; the summary is the line worth keeping, and a
+                // truncated stream is worth an operator's attention.
+                ReqwestStreamOutcome::InProgress => tracing::debug!(
+                    target: "reqwest_streams",
+                    parent: &self.span,
+                    items,
+                    bytes,
+                    elapsed_ms,
+                    "Streaming an HTTP body"
+                ),
+                ReqwestStreamOutcome::Failed => tracing::error!(
+                    target: "reqwest_streams",
+                    parent: &self.span,
+                    items,
+                    bytes,
+                    errors,
+                    elapsed_ms,
+                    outcome = outcome.as_str(),
+                    "Failed streaming an HTTP body"
+                ),
+                // Completed, and aborted: a consumer that stops reading early is ordinary.
+                _ => tracing::info!(
+                    target: "reqwest_streams",
+                    parent: &self.span,
+                    items,
+                    bytes,
+                    errors,
+                    elapsed_ms,
+                    outcome = outcome.as_str(),
+                    "Finished streaming an HTTP body"
+                ),
+            }
+        }
+
+        if let Some(handler) = &self.on_progress {
+            handler(&progress);
+        }
+    }
+}
+
+/// The accounting handle threaded through one stream's pipeline.
+///
+/// `None` inside means nobody is listening and every method is a no-op.
+#[derive(Clone)]
+pub(crate) struct Progress(Option<Arc<ProgressState>>);
+
+impl Progress {
+    /// Must be called before `bytes_stream()` consumes the response.
+    pub(crate) fn new(
+        format: &'static str,
+        response: &reqwest::Response,
+        options: &ReqwestStreamOptions,
+    ) -> Self {
+        Progress(ProgressState::maybe_new(format, response, options))
+    }
+}
+
+/// Counts the bytes of the response body.
+///
+/// Applied to the byte stream rather than the decoded one so that `bytes` is what actually
+/// arrived, independently of how many objects that turned into.
+pub(crate) fn count_bytes<'b, S>(
+    stream: S,
+    progress: &Progress,
+) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send + 'b
+where
+    S: Stream<Item = Result<Bytes, std::io::Error>> + Send + 'b,
+{
+    let progress = progress.clone();
+    stream.inspect_ok(move |chunk| {
+        if let Some(state) = &progress.0 {
+            state.record_bytes(chunk.len() as u64);
+        }
+    })
+}
+
+/// Counts items, reports errors, and owns the outcome state machine.
+///
+/// It wraps the outermost stream on purpose: every format's errors pass through here, and its
+/// `Drop` is the only way to notice a consumer that stopped reading early.
+pub(crate) fn instrument<'b, S>(
+    stream: S,
+    progress: Progress,
+) -> impl Stream<Item = S::Item> + Send + 'b
+where
+    S: Stream + Unpin + Send + 'b,
+    S::Item: ProgressItem,
+{
+    ProgressStream {
+        inner: stream,
+        progress,
+    }
+}
+
+struct ProgressStream<S> {
+    inner: S,
+    progress: Progress,
+}
+
+impl<S> Stream for ProgressStream<S>
+where
+    S: Stream + Unpin,
+    S::Item: ProgressItem,
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Safe without any projection: `Self: Unpin` whenever `S: Unpin`, which is exactly the
+        // bound above. That keeps `#![forbid(unsafe_code)]` intact.
+        let this = self.get_mut();
+
+        // Borrowed, not cloned: `progress` and `inner` are disjoint fields, so this avoids an
+        // atomic refcount bump on every single poll.
+        let Some(state) = this.progress.0.as_ref() else {
+            return Pin::new(&mut this.inner).poll_next(cx);
+        };
+
+        // Polling here drives the whole pipeline synchronously, reqwest and hyper included, so
+        // entering the span gives everything they log the stream's context. `poll_next` is
+        // synchronous, so this guard is never held across an await.
+        #[cfg(feature = "tracing")]
+        let _entered = state.span.enter();
+
+        state.mark_polled();
+
+        match Pin::new(&mut this.inner).poll_next(cx) {
+            Poll::Ready(Some(item)) => {
+                match item.stream_error() {
+                    Some(err) => state.record_error(err),
+                    None => state.record_item(),
+                }
+                Poll::Ready(Some(item))
+            }
+            Poll::Ready(None) => {
+                state.finalize(false);
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<S> Drop for ProgressStream<S> {
+    fn drop(&mut self) {
+        if let Some(state) = &self.progress.0 {
+            // A no-op when the stream already ran to completion, or was never polled.
+            state.finalize(true);
+        }
+    }
+}

--- a/src/protobuf_stream.rs
+++ b/src/protobuf_stream.rs
@@ -1,6 +1,7 @@
+use crate::observability::{self, Progress};
 use crate::protobuf_len_codec::ProtobufLenPrefixCodec;
 
-use crate::StreamBodyResult;
+use crate::{ReqwestStreamOptions, StreamBodyResult};
 use async_trait::*;
 use futures::TryStreamExt;
 use tokio_util::io::StreamReader;
@@ -43,6 +44,17 @@ pub trait ProtobufStreamResponse {
     fn protobuf_stream<'a, 'b, T>(self, max_obj_len: usize) -> impl futures::Stream<Item = StreamBodyResult<T>>  + Send + 'b
     where
         T: prost::Message + Default + Send + 'b;
+
+    /// Streams the response as batches of Protobuf messages, with [`ReqwestStreamOptions`].
+    ///
+    /// This is the variant that gives you the observability hooks: see
+    /// [`ReqwestStreamOptions::on_error`] and [`ReqwestStreamOptions::on_progress`].
+    fn protobuf_stream_with_options<'a, 'b, T>(
+        self,
+        options: ReqwestStreamOptions,
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + Send + 'b
+    where
+        T: prost::Message + Default + Send + 'b;
 }
 
 #[async_trait]
@@ -51,15 +63,29 @@ impl ProtobufStreamResponse for reqwest::Response {
     where
         T: prost::Message + Default + Send + 'b,
     {
-        let reader = StreamReader::new(
+        self.protobuf_stream_with_options(ReqwestStreamOptions::new().max_obj_len(max_obj_len))
+    }
+
+    fn protobuf_stream_with_options<'a, 'b, T>(
+        self,
+        options: ReqwestStreamOptions,
+    ) -> impl futures::Stream<Item = StreamBodyResult<T>> + Send + 'b
+    where
+        T: prost::Message + Default + Send + 'b,
+    {
+        // Taken before `bytes_stream()` consumes the response.
+        let progress = Progress::new("protobuf", &self, &options);
+
+        let reader = StreamReader::new(observability::count_bytes(
             self.bytes_stream()
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
-        );
+                .map_err(std::io::Error::other),
+            &progress,
+        ));
 
-        let codec = ProtobufLenPrefixCodec::<T>::new_with_max_length(max_obj_len);
-        let frames_reader = tokio_util::codec::FramedRead::new(reader, codec);
+        let codec = ProtobufLenPrefixCodec::<T>::new_with_max_length(options.max_obj_len);
+        let frames_reader = tokio_util::codec::FramedRead::with_capacity(reader, codec, options.buf_capacity);
 
-        frames_reader.into_stream()
+        observability::instrument(frames_reader.into_stream(), progress)
     }
 }
 

--- a/tests/progress_callbacks.rs
+++ b/tests/progress_callbacks.rs
@@ -1,0 +1,197 @@
+//! Coverage for the accounting callbacks, which are not gated on the `tracing` feature.
+//!
+//! Deliberately a separate binary from `tracing_progress.rs`, and deliberately one that never
+//! installs a subscriber. `tracing` caches each callsite's interest globally, so a callsite
+//! first evaluated with no subscriber registered is cached as "never interested" — which is
+//! exactly what these tests do, and exactly what would make the neighbouring tracing tests
+//! observe nothing. Keeping the two apart is what lets both be correct.
+#![cfg(feature = "json")]
+
+use futures::StreamExt;
+use std::io;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use reqwest_streams::{
+    JsonStreamResponse, ReqwestStreamOptions, ReqwestStreamOutcome, StreamBodyResult,
+};
+
+#[cfg(feature = "csv")]
+use reqwest_streams::CsvStreamResponse;
+
+/// Builds a real `reqwest::Response` out of exact byte chunks, with no server and no I/O.
+fn response_of(chunks: Vec<Result<&'static str, io::Error>>) -> reqwest::Response {
+    let body = reqwest::Body::wrap_stream(futures::stream::iter(
+        chunks
+            .into_iter()
+            .map(|chunk| chunk.map(|text| bytes::Bytes::from_static(text.as_bytes()))),
+    ));
+
+    reqwest::Response::from(http::Response::new(body))
+}
+
+/// The callbacks are the metrics path: they must fire on their own, with no subscriber and
+/// regardless of whether the `tracing` feature is even compiled in.
+#[tokio::test(flavor = "current_thread")]
+async fn callbacks_fire_without_a_subscriber() {
+    let errors = Arc::new(AtomicU64::new(0));
+    let terminal_items = Arc::new(AtomicU64::new(0));
+    let terminal_bytes = Arc::new(AtomicU64::new(0));
+
+    let seen_errors = errors.clone();
+    let seen_items = terminal_items.clone();
+    let seen_bytes = terminal_bytes.clone();
+
+    // 6 + 11 + 6 = 23 bytes; the middle line fails to decode.
+    let stream = response_of(vec![Ok("\"aaa\"\n{ not json\n\"ccc\"\n")])
+        .json_nl_stream_with_options::<String>(
+            ReqwestStreamOptions::new()
+                .max_obj_len(1024)
+                .on_error(move |_| {
+                    seen_errors.fetch_add(1, Ordering::Relaxed);
+                })
+                .on_progress(move |progress| {
+                    if progress.outcome != ReqwestStreamOutcome::InProgress {
+                        seen_items.store(progress.items, Ordering::Relaxed);
+                        seen_bytes.store(progress.bytes, Ordering::Relaxed);
+                        assert_eq!(progress.outcome, ReqwestStreamOutcome::Failed);
+                    }
+                }),
+        );
+
+    let results: Vec<StreamBodyResult<String>> = stream.collect().await;
+
+    assert_eq!(results.len(), 3, "the stream must not stop at the bad line");
+    assert_eq!(errors.load(Ordering::Relaxed), 1);
+    assert_eq!(terminal_items.load(Ordering::Relaxed), 2);
+    assert_eq!(terminal_bytes.load(Ordering::Relaxed), 23);
+}
+
+/// A consumer that stops reading early is ordinary client usage, not an anomaly.
+#[tokio::test(flavor = "current_thread")]
+async fn a_consumer_that_stops_early_reports_aborted() {
+    let outcome = Arc::new(std::sync::Mutex::new(None));
+    let seen = outcome.clone();
+
+    let stream = response_of(vec![Ok(r#"["aaa","bbb","ccc"]"#)])
+        .json_array_stream_with_options::<String>(ReqwestStreamOptions::new().on_progress(
+            move |progress| {
+                if progress.outcome != ReqwestStreamOutcome::InProgress {
+                    *seen.lock().unwrap() = Some((progress.outcome, progress.items));
+                }
+            },
+        ));
+
+    let mut stream = Box::pin(stream);
+    assert_eq!(stream.next().await.unwrap().unwrap(), "aaa");
+    drop(stream);
+
+    assert_eq!(
+        *outcome.lock().unwrap(),
+        Some((ReqwestStreamOutcome::Aborted, 1))
+    );
+}
+
+/// Building a stream and dropping it unconsumed is routine — a `?` short-circuits, a function
+/// returns early — and none of it may be reported as an abort.
+#[tokio::test(flavor = "current_thread")]
+async fn a_stream_that_was_never_polled_reports_nothing() {
+    let reported = Arc::new(AtomicU64::new(0));
+    let seen = reported.clone();
+
+    let stream = response_of(vec![Ok(r#"["aaa"]"#)]).json_array_stream_with_options::<String>(
+        ReqwestStreamOptions::new().on_progress(move |_| {
+            seen.fetch_add(1, Ordering::Relaxed);
+        }),
+    );
+
+    drop(stream);
+
+    assert_eq!(reported.load(Ordering::Relaxed), 0);
+}
+
+/// With nobody listening the pipeline is left untouched; the stream must still behave.
+#[tokio::test(flavor = "current_thread")]
+async fn passes_through_when_nobody_listens() {
+    let stream = response_of(vec![Ok(r#"["aaa","bbb"]"#)]).json_array_stream::<String>(1024);
+    let items: Vec<String> = stream.map(|item| item.unwrap()).collect().await;
+    assert_eq!(items, vec!["aaa", "bbb"]);
+}
+
+/// The existing positional-argument methods must behave exactly as before.
+#[tokio::test(flavor = "current_thread")]
+async fn the_existing_api_still_enforces_max_obj_len() {
+    let stream =
+        response_of(vec![Ok(r#"["aaaaaaaaaaaaaaaaaaaaaaaaaaaa"]"#)]).json_array_stream::<String>(8);
+    let results: Vec<StreamBodyResult<String>> = stream.collect().await;
+
+    assert!(results.iter().any(|item| item.is_err()));
+}
+
+/// Progress is driven from arriving bytes, not only from decoded items: a single item can take
+/// a long time to arrive, and reporting nothing until it lands would defeat the point.
+#[tokio::test(flavor = "current_thread")]
+async fn progress_is_reported_before_any_item_completes() {
+    let ticks = Arc::new(AtomicU64::new(0));
+    let seen = ticks.clone();
+
+    // Two chunks of an array that never closes, so not one item is ever decoded.
+    let stream = response_of(vec![Ok(r#"["aaa"#), Ok(r#"bbb"#)])
+        .json_array_stream_with_options::<String>(
+            ReqwestStreamOptions::new()
+                .max_obj_len(1024)
+                .progress_interval(std::time::Duration::ZERO)
+                .on_progress(move |progress| {
+                    if progress.outcome == ReqwestStreamOutcome::InProgress {
+                        assert_eq!(progress.items, 0, "no item can have completed yet");
+                        assert!(progress.bytes > 0, "bytes must have been counted");
+                        seen.fetch_add(1, Ordering::Relaxed);
+                    }
+                }),
+        );
+
+    let _results: Vec<StreamBodyResult<String>> = stream.collect().await;
+
+    assert!(
+        ticks.load(Ordering::Relaxed) > 0,
+        "arriving bytes must report progress even with no completed items"
+    );
+}
+
+/// `.skip(1)` would drop the header frame whether it decoded or not, hiding a header line that
+/// blew the length limit and reporting the stream as cleanly completed.
+#[cfg(feature = "csv")]
+#[tokio::test(flavor = "current_thread")]
+async fn a_failing_csv_header_is_not_swallowed() {
+    let errors = Arc::new(AtomicU64::new(0));
+    let outcome = Arc::new(std::sync::Mutex::new(None));
+    let seen_errors = errors.clone();
+    let seen_outcome = outcome.clone();
+
+    // The header line is longer than `max_obj_len`, so framing it fails.
+    let stream = response_of(vec![Ok("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+real,row
+")])
+    .csv_stream_with_options::<(String, String)>(
+        true,
+        b',',
+        ReqwestStreamOptions::new()
+            .max_obj_len(8)
+            .on_error(move |_| {
+                seen_errors.fetch_add(1, Ordering::Relaxed);
+            })
+            .on_progress(move |progress| {
+                if progress.outcome != ReqwestStreamOutcome::InProgress {
+                    *seen_outcome.lock().unwrap() = Some(progress.outcome);
+                }
+            }),
+    );
+
+    let _results: Vec<StreamBodyResult<(String, String)>> = stream.collect().await;
+
+    assert!(
+        errors.load(Ordering::Relaxed) > 0,
+        "the header's framing error must be reported, not skipped"
+    );
+    assert_eq!(*outcome.lock().unwrap(), Some(ReqwestStreamOutcome::Failed));
+}

--- a/tests/tracing_progress.rs
+++ b/tests/tracing_progress.rs
@@ -1,0 +1,267 @@
+//! Coverage for what the `tracing` feature actually emits, and for the callbacks that report
+//! the same accounting without it.
+//!
+//! This lives in its own test binary on purpose. `tracing` caches each callsite's interest
+//! globally, and a callsite first evaluated while no subscriber is registered is cached as
+//! "never interested". Sharing a process with tests that install no subscriber therefore makes
+//! a thread-local `set_default` race with that cache; a dedicated binary has no such
+//! neighbours.
+#![cfg(all(feature = "tracing", feature = "json"))]
+
+use futures::StreamExt;
+use std::io;
+use std::sync::{Arc, Mutex};
+use tracing_subscriber::fmt::MakeWriter;
+
+use reqwest_streams::{JsonStreamResponse, ReqwestStreamOptions, StreamBodyResult};
+
+/// Installing a subscriber rebuilds `tracing`'s global callsite interest cache, so two tests
+/// doing it at once would race exactly the way this binary exists to avoid. One at a time.
+///
+/// A `tokio` mutex rather than a `std` one: it is held across awaits, and it does not carry
+/// poisoning, so one failing test cannot cascade into the others.
+static TRACING: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[derive(Clone)]
+struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for SharedWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for SharedWriter {
+    type Writer = SharedWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Builds a real `reqwest::Response` out of exact byte chunks, with no server and no I/O.
+///
+/// A server would make chunk boundaries and timing non-deterministic, and `src/test_client.rs`
+/// is `#[cfg(test)]` and so invisible from here anyway.
+fn response_of(chunks: Vec<Result<&'static str, io::Error>>) -> reqwest::Response {
+    let body = reqwest::Body::wrap_stream(futures::stream::iter(
+        chunks
+            .into_iter()
+            .map(|chunk| chunk.map(|text| bytes::Bytes::from_static(text.as_bytes()))),
+    ));
+
+    reqwest::Response::from(http::Response::new(body))
+}
+
+/// Runs `body` with a capturing subscriber installed at `level`, and returns what was logged.
+async fn capture_at<F, Fut>(level: tracing::Level, body: F) -> String
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let _serialized = TRACING.lock().await;
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(level)
+        .with_ansi(false)
+        .with_writer(SharedWriter(buffer.clone()))
+        .finish();
+
+    // Not `set_global_default`: `capture_at` is called by several tests in this binary.
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    body().await;
+
+    let captured = buffer.lock().unwrap().clone();
+    String::from_utf8(captured).unwrap()
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn reports_the_summary_at_info() {
+    let captured = capture_at(tracing::Level::INFO, || async {
+        let stream =
+            response_of(vec![Ok(r#"["aaa","bbb","ccc"]"#)]).json_array_stream::<String>(1024);
+        let items: Vec<String> = stream.map(|item| item.unwrap()).collect().await;
+        assert_eq!(items, vec!["aaa", "bbb", "ccc"]);
+    })
+    .await;
+
+    assert!(captured.contains("INFO"), "unexpected output: {captured}");
+    assert!(
+        captured.contains("reqwest_streams::response_stream"),
+        "the summary must be recorded on the stream span: {captured}"
+    );
+    assert!(
+        captured.contains(r#"format="json_array""#),
+        "the span must name the format: {captured}"
+    );
+    assert!(
+        captured.contains("items=3"),
+        "unexpected output: {captured}"
+    );
+    assert!(
+        captured.contains("bytes=19"),
+        "unexpected output: {captured}"
+    );
+    assert!(
+        captured.contains("errors=0"),
+        "unexpected output: {captured}"
+    );
+    assert!(
+        captured.contains(r#"outcome="completed""#),
+        "unexpected output: {captured}"
+    );
+    assert!(
+        captured.contains("max_obj_len=1024"),
+        "unexpected output: {captured}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn reports_progress_at_debug() {
+    // Item-stepped rather than time-based, so the test does not have to sleep for a second.
+    let captured = capture_at(tracing::Level::DEBUG, || async {
+        let stream = response_of(vec![Ok(r#"["aaa","bbb","ccc"]"#)])
+            .json_array_stream_with_options::<String>(
+                ReqwestStreamOptions::new()
+                    .max_obj_len(1024)
+                    .progress_items(1),
+            );
+        let _items: Vec<StreamBodyResult<String>> = stream.collect().await;
+    })
+    .await;
+
+    let ticks = captured.matches("Streaming an HTTP body").count();
+    assert_eq!(ticks, 3, "expected one tick per item: {captured}");
+    assert!(
+        captured.contains("Finished streaming an HTTP body"),
+        "the summary must still be emitted: {captured}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn reports_per_chunk_at_trace() {
+    let captured = capture_at(tracing::Level::TRACE, || async {
+        let stream =
+            response_of(vec![Ok(r#"["aaa","#), Ok(r#""bbb"]"#)]).json_array_stream::<String>(1024);
+        let _items: Vec<StreamBodyResult<String>> = stream.collect().await;
+    })
+    .await;
+
+    let chunks = captured.matches("Read an HTTP body chunk").count();
+    assert_eq!(chunks, 2, "expected one event per body chunk: {captured}");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn reports_aborted_when_the_consumer_stops_early() {
+    let captured = capture_at(tracing::Level::INFO, || async {
+        let stream =
+            response_of(vec![Ok(r#"["aaa","bbb","ccc"]"#)]).json_array_stream::<String>(1024);
+        let mut stream = Box::pin(stream);
+        let first = stream.next().await;
+        assert_eq!(first.unwrap().unwrap(), "aaa");
+        drop(stream);
+    })
+    .await;
+
+    assert!(
+        captured.contains(r#"outcome="aborted""#),
+        "stopping early must report as aborted: {captured}"
+    );
+    assert!(
+        captured.contains("items=1"),
+        "the partial total must survive the abort: {captured}"
+    );
+}
+
+/// Building a stream and dropping it unconsumed is routine on the client — a `?`
+/// short-circuits, a function returns early — and every doctest in this crate does exactly
+/// that. None of it may report an abort.
+#[tokio::test(flavor = "current_thread")]
+async fn reports_nothing_when_never_polled() {
+    let captured = capture_at(tracing::Level::TRACE, || async {
+        let stream = response_of(vec![Ok(r#"["aaa"]"#)]).json_array_stream::<String>(1024);
+        drop(stream);
+    })
+    .await;
+
+    assert!(
+        !captured.contains("outcome="),
+        "a stream that was never polled must report nothing: {captured}"
+    );
+}
+
+/// The JSON Lines and CSV formats produce their decoding errors from a successfully framed
+/// line, so the stream carries on. Finalizing at the first error would stop counting the rest
+/// of a stream that is still perfectly healthy.
+#[tokio::test(flavor = "current_thread")]
+async fn a_decoding_error_does_not_stop_a_json_nl_stream() {
+    let captured = capture_at(tracing::Level::INFO, || async {
+        let stream = response_of(vec![Ok("\"aaa\"\n{ not json\n\"ccc\"\n\"ddd\"\n")])
+            .json_nl_stream::<String>(1024);
+        let results: Vec<StreamBodyResult<String>> = stream.collect().await;
+
+        assert_eq!(results.len(), 4, "the stream must not stop at the bad line");
+        assert!(results[0].is_ok());
+        assert!(results[1].is_err());
+        assert!(results[2].is_ok(), "reading must resume after the error");
+        assert!(results[3].is_ok());
+    })
+    .await;
+
+    assert!(
+        captured.contains("items=3"),
+        "the items after the bad line must still be counted: {captured}"
+    );
+    assert!(
+        captured.contains("errors=1"),
+        "unexpected output: {captured}"
+    );
+    assert!(
+        captured.contains(r#"outcome="failed""#),
+        "a stream that saw an error ends as failed: {captured}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn reports_the_error_kind() {
+    let captured = capture_at(tracing::Level::ERROR, || async {
+        let stream = response_of(vec![Ok(r#"["aaaaaaaaaaaaaaaaaaaaaaaaaaaa"]"#)])
+            .json_array_stream::<String>(8);
+        let results: Vec<StreamBodyResult<String>> = stream.collect().await;
+        assert!(results.iter().any(|item| item.is_err()));
+    })
+    .await;
+
+    assert!(
+        captured.contains(r#"error_kind="max_len""#),
+        "the error event must carry its kind: {captured}"
+    );
+    assert!(
+        captured.contains("An error occurred while streaming an HTTP body"),
+        "unexpected output: {captured}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn reports_a_transport_error_as_failed() {
+    let captured = capture_at(tracing::Level::ERROR, || async {
+        let stream = response_of(vec![
+            Ok("\"aaa\"\n"),
+            Err(io::Error::new(io::ErrorKind::ConnectionReset, "boom")),
+        ])
+        .json_nl_stream::<String>(1024);
+        let _results: Vec<StreamBodyResult<String>> = stream.collect().await;
+    })
+    .await;
+
+    assert!(
+        captured.contains(r#"outcome="failed""#),
+        "a broken body must report as failed: {captured}"
+    );
+}


### PR DESCRIPTION
Mirrors the observability axum-streams gained in 0.27 and 0.28, adapted to the consuming side: a `ReqwestStreamOptions` builder with `on_error`/`on_progress` callbacks that are always available, plus an opt-in `tracing` feature that reports items, bytes, errors and outcome on a `reqwest_streams::response_stream` span. Existing methods are unchanged and now delegate through the new options, so nothing breaks.

Three things work differently from the server side because the client genuinely differs: an error does not end the stream (JSON Lines and CSV keep reading after a bad line), a stream that was built but never polled reports nothing, and stopping early is reported as an ordinary `aborted` rather than a failure.

Also bumps the axum-streams dev-dependency to 0.28, and fixes `deserialize_csv_stream`, which has been failing on master since the 0.26 bump because `StreamBodyAs::csv` now writes a header row. The declared MSRV moves to 1.85 to match what the crate has actually required since reqwest 0.13; the new tracing dependency needs only 1.65 and is not the constraint.